### PR TITLE
Fixes ceylon/ceylon-compiler#2117

### DIFF
--- a/src/com/redhat/ceylon/common/tool/StandardArgumentParsers.java
+++ b/src/com/redhat/ceylon/common/tool/StandardArgumentParsers.java
@@ -7,7 +7,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -164,7 +166,7 @@ public class StandardArgumentParsers {
                 }
                 return result;
             } else {
-                return Collections.emptyList();
+                return new ArrayList<>(EnumSet.allOf(enumClass));
             }
         }
     }


### PR DESCRIPTION
Fixes ceylon/ceylon-compiler#2117, also see ceylon/ceylon-compiler#2119 for the test

This make the enum parser return all values of an Enum, because `EnumSet.copy()` doen't accept empty collections.

This fix was mentored by @FroMage during the hackergarten at Devoxx France 2015