### PR TITLE
propagate jvm exit code

### DIFF
--- a/bin/ceylon.bat
+++ b/bin/ceylon.bat
@@ -37,3 +37,5 @@ set "LIB=%CEYLON_HOME%\lib"
     %*
 
 endlocal
+
+if %errorlevel% neq 0 exit /B %errorlevel%


### PR DESCRIPTION
In the current version of `ceylon.bat` the exit code of the jvm is not propagated to be also the exit code of `ceylon.bat`

So, for instance with something like this in an Ant file
```xml
<exec executable="ceylon.bat" failonerror="true">
  <arg value="compile"/>
</exec>
```
this never stops the Ant script even when the compilation fails (FTR, yes I know that there is a Ant task dedicated to the compilation of Ceylon and I don't need to use `ceylon.bat` here)

This pull request fixes this problem.