### PR TITLE
add Dart and LLVM to Backend enum

### DIFF
--- a/src/com/redhat/ceylon/common/Backend.java
+++ b/src/com/redhat/ceylon/common/Backend.java
@@ -3,7 +3,9 @@ package com.redhat.ceylon.common;
 public enum Backend {
     None(""),
     Java("jvm"),
-    JavaScript("js");
+    JavaScript("js"),
+    Dart("dart"),
+    LLVM("llvm");
     
     public final String nativeAnnotation;
     


### PR DESCRIPTION
Note: I don't know if this is sufficient or even correct. But I have been using a version with the additional `dart` enum value for a couple weeks without any noticeable problems for the js and jvm backends.

cc @sadmac7000
